### PR TITLE
Update lib.js

### DIFF
--- a/js/lib.js
+++ b/js/lib.js
@@ -25,7 +25,7 @@ if (!Function.prototype.bind) {
 	var p = 'browser';
 	var em = false;
 
-	if (navigator.userAgent.match(/smarttv/i)) p = 'samsung';
+	if (navigator.userAgent.match(/smart-tv/i)) p = 'samsung';
 	if (navigator.userAgent.match(/Tizen/i)) p = 'tizen';
 	if (navigator.userAgent.match(/LG Browser/i)) p = 'lg';
 	if (navigator.userAgent.match(/WebOS|Web0S/i)) p = 'webos';


### PR DESCRIPTION
fix detection of Samsung (before - Philips could be detected as Samsung, because of "smarttv" substring in User-Agent). Changed to work as suggested by http://developer.samsung.com/technical-doc/view.do?v=T000000203 ("Identify the Samsung Internet for SmartTV by using the “SMART-TV” keyword.")
